### PR TITLE
docs: Update AGENTS.md and README.md for improved command options for…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,24 +30,24 @@ Commands:
 
 ## 4. Rename Command Options (Summary)
 
-| Option | Alias | Type | Notes |
-|--------|-------|------|-------|
-| --directory | -dir | TEXT | Target directory root |
-| --files | -files | TEXT | One or more explicit files (may repeat) |
-| --trim | -t | FLAG | Clean noisy filename segments |
-| --dry-run | -d | FLAG | No mutation; output planned changes |
-| --pinyin | -py | FLAG | Add leading pinyin initial (Chinese title) |
-| --includes | -i | TEXT | Process only these extensions (repeatable) |
-| --excludes | -e | TEXT | Skip these extensions (repeatable) |
-| --output | -o | FLAG | Print only new names (quiet mode) |
-| --recursive | -r | FLAG | Descend into subdirectories |
-| --unzip | -u | FLAG | Extract ZIPs then operate on contents |
-| --password | -pwd | TEXT | ZIP password (if encrypted) |
-| --ai | -ai | FLAG | Enable AI beautification / translation |
-| --model | -m | TEXT | AI model identifier (e.g. gpt-4o-mini) |
-| --api-key | -key | TEXT | API key (overrides config) |
-| --endpoint | -ep | TEXT | Custom API base URL |
-| --platform | -p | TEXT | Platform hint (e.g. GBA, NDS) |
+| Option      | Alias  | Type | Notes                                      |
+| ----------- | ------ | ---- | ------------------------------------------ |
+| --directory | -dir   | TEXT | Target directory root                      |
+| --files     | -files | TEXT | One or more explicit files (may repeat)    |
+| --trim      | -t     | FLAG | Clean noisy filename segments              |
+| --dry-run   | -d     | FLAG | No mutation; output planned changes        |
+| --pinyin    | -py    | FLAG | Add leading pinyin initial (Chinese title) |
+| --includes  | -i     | TEXT | Process only these extensions (repeatable) |
+| --excludes  | -e     | TEXT | Skip these extensions (repeatable)         |
+| --output    | -o     | FLAG | Print only new names (quiet mode)          |
+| --recursive | -r     | FLAG | Descend into subdirectories                |
+| --unzip     | -u     | FLAG | Extract ZIPs then operate on contents      |
+| --password  | -pwd   | TEXT | ZIP password (if encrypted)                |
+| --ai        | -ai    | FLAG | Enable AI beautification / translation     |
+| --model     | -m     | TEXT | AI model identifier (e.g. gpt-4o-mini)     |
+| --api-key   | -key   | TEXT | API key (overrides config)                 |
+| --endpoint  | -ep    | TEXT | Custom API base URL                        |
+| --platform  | -p     | TEXT | Platform hint (e.g. GBA, NDS)              |
 
 Minimal example (recursive + AI + pinyin, preview only; batched lookups):
 
@@ -57,12 +57,12 @@ renamer rename -r -d -ai -py -dir "~/ROMs" -model "gpt-4o-mini" -p "GBA" --ai-ba
 
 ## 5. Revert Command Options (Summary)
 
-| Option | Alias | Type | Notes |
-|--------|-------|------|-------|
-| --directory | -dir | TEXT | Root to search for renamed files |
-| --files | -files | TEXT | Explicit files to revert |
-| --recursive | -r | FLAG | Traverse subfolders |
-| --dry-run | -d | FLAG | Show intended reverts only |
+| Option      | Alias  | Type | Notes                            |
+| ----------- | ------ | ---- | -------------------------------- |
+| --directory | -dir   | TEXT | Root to search for renamed files |
+| --files     | -files | TEXT | Explicit files to revert         |
+| --recursive | -r     | FLAG | Traverse subfolders              |
+| --dry-run   | -d     | FLAG | Show intended reverts only       |
 
 Example (dry-run revert):
 
@@ -146,14 +146,18 @@ poetry run bump-major
 
 Optional CI sync of const.py:
 
-- If you use Option B (Release Drafter tag) and want `const.py` to reflect the tag in build artifacts without committing it, add a pre-build step:
+- Using Option B (Release Drafter tag), set `APP_VERSION` and invoke the unified Poetry script instead of raw bump2version:
 
 ```bash
-# Example: set const.py to the tag-derived version in CI without committing changes
-bump2version --allow-dirty --new-version "$APP_VERSION" patch
+# Example: set const.py and pyproject.toml to tag-derived version (no commit required)
+APP_VERSION="$APP_VERSION" poetry run bump
 ```
 
-This ensures the app's About/version output matches the release tag.
+Behavior:
+ 
+1. If `APP_VERSION` is present the script writes that exact version to both `pyproject.toml` and `ai_rom_batch_renamer/modules/const.py`.
+2. If `APP_VERSION` is absent it falls back to a patch bump via bump2version.
+3. Keeps runtime About/version output aligned with the release tag.
 
 ## 8. Exit / Error Semantics (Recommended)
 
@@ -187,12 +191,12 @@ This ensures the app's About/version output matches the release tag.
 
 ## 12. Troubleshooting
 
-| Symptom | Cause | Mitigation |
-|---------|-------|-----------|
-| Slow runs | Large ZIPs / many API calls | Use includes/excludes, enable caching when available |
-| Wrong year in title | AI hallucination | Provide platform (`-p`), consider manual override pass |
-| Missing pinyin initial | Non-Chinese title | Expected (only added when Chinese characters parsed) |
-| Revert fails | Cache entry missing | Ensure cache file not deleted; fallback manual rename |
+| Symptom                | Cause                       | Mitigation                                             |
+| ---------------------- | --------------------------- | ------------------------------------------------------ |
+| Slow runs              | Large ZIPs / many API calls | Use includes/excludes, enable caching when available   |
+| Wrong year in title    | AI hallucination            | Provide platform (`-p`), consider manual override pass |
+| Missing pinyin initial | Non-Chinese title           | Expected (only added when Chinese characters parsed)   |
+| Revert fails           | Cache entry missing         | Ensure cache file not deleted; fallback manual rename  |
 
 ## 13. Contribution Hooks (Agent Perspective)
 

--- a/README.md
+++ b/README.md
@@ -318,13 +318,14 @@ poetry run bump-minor
 poetry run bump-major
 ```
 
-在 CI 的 Option B 模式下（Release Drafter 生成 tag），如需让构建产物内的 `const.py` 与 tag 保持一致但不提交修改，可在构建前加入（允许工作区脏状态）：
+在 CI 的 Option B 模式下（Release Drafter 生成 tag），构建任务会设置 `APP_VERSION` 环境变量并运行统一脚本：
 
 ```bash
-bump2version --allow-dirty --new-version "$APP_VERSION" patch
+# 同步 pyproject.toml 与 ai_rom_batch_renamer/modules/const.py
+APP_VERSION="$APP_VERSION" poetry run bump
 ```
 
-这样应用的 About/版本输出将与发布标签一致。
+如果提供了 `APP_VERSION`，该脚本会直接写入对应版本；否则会回退为 patch 自动递增。这样应用的 About/版本输出将与发布标签一致。
 
 ## 🗺️ Roadmap | 开发路线图
 


### PR DESCRIPTION
This pull request updates documentation to clarify and standardize command option tables and improve the release/versioning workflow instructions for both English and Chinese readers. The changes enhance consistency, provide clearer instructions for CI version syncing, and improve table formatting in the documentation.

Documentation formatting improvements:

* Standardized the formatting of command option tables in `AGENTS.md` for both the Rename and Revert commands, improving readability and consistency. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L34-R34) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L61-R61) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L191-R195)

Release/versioning workflow updates:

* Updated CI version bump instructions in both `AGENTS.md` and `README.md` to recommend using a unified Poetry script (`poetry run bump`) that writes the version to both `pyproject.toml` and `const.py`, ensuring About/version output matches the release tag and improving clarity for both English and Chinese users. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L149-R160) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L321-R328)…matting and CI instructions