### PR TITLE
Release: 2.1.1

### DIFF
--- a/ai_rom_batch_renamer/modules/const.py
+++ b/ai_rom_batch_renamer/modules/const.py
@@ -1,1 +1,5 @@
 VERSION = "2.1.0"
+
+# Canonical region codes produced by getRegion and used across the app.
+# Keep this list in sync with any region mapping logic.
+ALLOWED_REGION_CODES = {"US", "JP", "EU", "繁", "简", "简&繁", "WW", "UE"}

--- a/ai_rom_batch_renamer/modules/utils.py
+++ b/ai_rom_batch_renamer/modules/utils.py
@@ -4,6 +4,8 @@ import hashlib
 import zipfile
 import regex
 
+from ai_rom_batch_renamer.modules import const as constModule
+
 
 def isSystemOrHiddenFile(file: str) -> bool:
 
@@ -211,7 +213,7 @@ def isFileRenamed(filePath: str) -> bool:
         # Validate that every region token is among the allowed canonical set.
         # Canonical region codes are those produced by rename logic (getRegion):
         # US, JP, EU, 繁, 简, 简&繁, WW, UE plus special block Hack.
-        allowed_regions = {"US", "JP", "EU", "繁", "简", "简&繁", "WW", "UE"}
+        allowed_regions = constModule.ALLOWED_REGION_CODES
         for t in region_tokens:
             if t == "Hack":
                 continue


### PR DESCRIPTION
This pull request introduces a small codebase improvement by centralizing the canonical region codes used throughout the application. The main change is the creation of a single source of truth for allowed region codes in `const.py`, and updating the region validation logic to reference this constant.

Centralization of region codes:

* Added `ALLOWED_REGION_CODES` set to `ai_rom_batch_renamer/modules/const.py` to define canonical region codes in one place.
* Updated region validation in `isFileRenamed` to use `constModule.ALLOWED_REGION_CODES` instead of a hardcoded set, ensuring consistency across the app.
* Imported the constants module in `ai_rom_batch_renamer/modules/utils.py` to access the centralized region codes.