### PR TITLE
fix: Use original base name for renaming logic in the rename function

### DIFF
--- a/ai_rom_batch_renamer/modules/rename.py
+++ b/ai_rom_batch_renamer/modules/rename.py
@@ -194,13 +194,15 @@ def rename(options: dict):
             en = (result.get('englishTitle') or '').strip()
             year = (result.get('releaseYear') or '').strip()
 
+            
+            # Use original base name as source of truth
             new_base = None
             if cn and en:
                 # CN + EN
-                new_base = f"{cn} ({en})"
+                new_base = f"{romFile.baseName} ({en})"
             elif cn:
                 # CN only
-                new_base = cn
+                new_base = f"{romFile.baseName}"
             elif en:
                 # EN only
                 new_base = en


### PR DESCRIPTION
This pull request updates the logic for generating new file base names in the `rename` function of `ai_rom_batch_renamer/modules/rename.py`. The change ensures that the original base name of the ROM file is used as the source of truth when constructing the new base name, rather than relying solely on metadata fields.

Base name generation logic update:

* Modified the construction of `new_base` to use `romFile.baseName` for cases where both Chinese and English titles are present, or only the Chinese title is present, ensuring consistency and accuracy in file naming.